### PR TITLE
DS1 PTDE HKX Animation Import

### DIFF
--- a/io_soulstruct/animation/gui.py
+++ b/io_soulstruct/animation/gui.py
@@ -22,7 +22,7 @@ class AnimationImportExportPanel(bpy.types.Panel):
     # noinspection PyUnusedLocal
     def draw(self, context):
         settings = context.scene.soulstruct_settings
-        if not settings.is_game("DARK_SOULS_DSR", "ELDEN_RING"):
+        if not settings.is_game("DARK_SOULS_PTDE", "DARK_SOULS_DSR", "ELDEN_RING"):
             self.layout.label(text="Import/Export for DSR and ER only.")
             return
 

--- a/io_soulstruct/animation/utilities.py
+++ b/io_soulstruct/animation/utilities.py
@@ -16,7 +16,7 @@ import numpy as np
 from pathlib import Path
 from soulstruct_havok.core import HKX
 from soulstruct_havok.utilities.maths import TRSTransform
-from soulstruct_havok.wrappers import hkx2015, hkx2016, hkx2018
+from soulstruct_havok.wrappers import hkx2010, hkx2015, hkx2016, hkx2018
 from soulstruct_havok.wrappers.hkx2015 import AnimationHKX, SkeletonHKX, ANIBND
 from soulstruct.containers import BinderEntry
 from io_soulstruct.exceptions import UnsupportedGameError
@@ -35,6 +35,8 @@ def read_animation_hkx_entry(hkx_entry: BinderEntry, compendium: HKX = None) -> 
         hkx = hkx2015.AnimationHKX.from_bytes(data, compendium=compendium)
     elif version == b"20160100":  # non-From
         hkx = hkx2016.AnimationHKX.from_bytes(data, compendium=compendium)
+    elif data[0x28:0x36] == b"hk_2010.2.0-r1":
+        hkx = hkx2010.AnimationHKX.from_bytes(data, compendium=compendium)
     else:
         raise UnsupportedGameError(
             f"Cannot support this HKX animation file version in Soulstruct and/or Blender: {version}"
@@ -53,6 +55,8 @@ def read_skeleton_hkx_entry(hkx_entry: BinderEntry, compendium: HKX = None) -> S
         hkx = hkx2015.SkeletonHKX.from_bytes(data, compendium=compendium)
     elif version == b"20160100":  # non-From
         hkx = hkx2016.SkeletonHKX.from_bytes(data, compendium=compendium)
+    elif data[0x28:0x36] == b"hk_2010.2.0-r1":
+        hkx = hkx2010.SkeletonHKX.from_bytes(data, compendium=compendium)
     else:
         raise UnsupportedGameError(
             f"Cannot support this HKX skeleton file version in Soulstruct and/or Blender: {version}"


### PR DESCRIPTION
I noticed that animation import for PTDE is checkmarked on the table in the latest README, but it isn't available in blender. I tacked on a couple lines to make get import working, though it's mostly untested.